### PR TITLE
refactor(package.json): update repo's URL from user to org

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/phigasui/zine.git"
+    "url": "git+https://github.com/wakate-web-nagoya/zine.git"
   },
   "keywords": [
     "zine",
@@ -19,9 +19,9 @@
   "author": "phigasui",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/phigasui/zine/issues"
+    "url": "https://github.com/wakate-web-nagoya/zine/issues"
   },
-  "homepage": "https://github.com/phigasui/zine#readme",
+  "homepage": "https://github.com/wakate-web-nagoya/zine#readme",
   "dependencies": {
     "@hyperapp/router": "^0.4.1",
     "hyperapp": "^1.2.0"


### PR DESCRIPTION
## e25d59b: refactor(package.json): update repo's URL from user to org

Realising that @phigasui has transferred the ownership of this repository from his own GitHub user account to the @wakate-web-nagoya GitHub organisation account. While URL redirections automatically occur from the old repository's URLs to the current repository's URLs when performing `npm home`, `npm issues` and `npm docs` commands, it is just nice to be changed to the current URLs accordingly in the `package.json` file.

---

### Message from the collaborator

Please review my commit and if necessary, rectify as appropriate.

I have decided to remain the author of this repository to be @phigasui, please consider if changing the author to be @wakate-web-nagoya is appropriate.

Thank you!

sho