### PR TITLE
docs(README.md): exclude redundant npm `run` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ npm install
 ```
 
 
-### Test(hot reload)
+### Test (hot reload)
 
 ```bash
-npm run start
+npm start
 ```
 
 


### PR DESCRIPTION
### 07bb39b: docs(README.md): exclude redundant npm `run` subcommand

Some npm script commands have their shorthand aliases, e.g. `start`, `stop` and `test`.

The `npm start` command is an alias of the `npm run start` command. The shorter the shell command, the more time you get a life outside programming :P Let's be happy with this XD

This commit also inserts a single space where I think is appropriate.

---

### Message from the collaborator

Please review my commit and if necessary, rectify as appropriate.

**NOTE:** This commit only suggests a documentation change; it does not change any behaviour of the project. The both `npm run start` and `npm start` commands work fine like charms anyway.

Thank you!

sho