### PR TITLE
style(dist/index.html): relocate HTML `<meta>` tag

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,7 +1,6 @@
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >
-
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   </head>
   <body>
     <script src="./js/bundle.js"></script>


### PR DESCRIPTION
## 2623b47: HTML `<meta>` tags should be located inside the `<head>` tags.

In the 3da8bd6 commit, a `<meta>` tag was located outside `<head>` tags
at the top of the `index.html` file; this should not be legit.

This commit also make the charset setting `UTF-8` lower case, as
suggested in the Google Style Guide for HTML; please see:
https://google.github.io/styleguide/htmlcssguide.html#Encoding

---

### Message from the collaborator

Please review my commit(s) and if necessary, rectify as appropriate.

Thank you!

sho